### PR TITLE
C: メソッドチェーン（大嘘）

### DIFF
--- a/RADWIMPS.c
+++ b/RADWIMPS.c
@@ -1,33 +1,32 @@
 #include <stdio.h>
 
 
-struct RADWIMPS;
-struct RADWIMPS* then();
-struct RADWIMPS* 世();
-
-
 struct RADWIMPS {
-    struct RADWIMPS* (*then)();
-    struct RADWIMPS* (*世)();
+    struct RADWIMPS (*then)();
+    struct RADWIMPS (*世)();
 };
+
+struct RADWIMPS then();
+struct RADWIMPS 世();
+
 struct RADWIMPS RADWIMPS = { then, 世 };
 
 
-struct RADWIMPS* then() {
+struct RADWIMPS then() {
     printf("前");
 
-    return &RADWIMPS;
+    return RADWIMPS;
 }
 
-struct RADWIMPS* 世() {
-    printf("世");
+struct RADWIMPS 世() {
+    printf("世\n");
     
-    return &RADWIMPS;
+    return RADWIMPS;
 }
 
 
 int main() {
-    RADWIMPS.then()->then()->then()->世();
+    RADWIMPS.then().then().then().世();
     
     return 0;
 }


### PR DESCRIPTION
- アロー演算子をピリオドに置き換え
- 最後に改行コードを出力
- プロトタイプ宣言を構造体定義の後ろに持ってきた

memo: GCCだと非ASCII文字の識別子に対応していないんですね。Clangでコンパイルが通ることを確認しました