### PR TITLE
[Languages] C preprocessor

### DIFF
--- a/RADWIMPS.h
+++ b/RADWIMPS.h
@@ -1,0 +1,4 @@
+#define then() "前"
+#define 世() "世\n"
+#define RADWIMPS then()then()then()世()
+#pragma message(RADWIMPS)


### PR DESCRIPTION
includeするとnoteで前前前世を吐くようになります。
GCC10.1でのみ動作（pragma messageを使っているのと、マクロ名がASCIIではないため）


（はたしてこれは大丈夫なのでしょうか・・・？🤔🤔🤔）