### PR TITLE
[Languages] Erlang

### DIFF
--- a/RADWIMPS.erl
+++ b/RADWIMPS.erl
@@ -1,0 +1,27 @@
+#!/usr/bin/env escript
+
+main(_) ->
+    io:setopts([{encoding, unicode}]),
+    RADWIMPS = spawn(fun() -> rad_process() end),
+    [send_sync(self(), RADWIMPS, Msg)
+        || Msg <- [then, then, then, '世']].
+
+send_sync(From, To, Msg) ->
+    To ! {From, Msg},
+    receive
+        done -> ok;
+        _ -> exit("main process received unexpected message")
+    end.
+
+rad_process() ->
+    receive
+        {Self, '世'} ->
+            io:format("世~n"),
+            Self ! done,
+            rad_process();
+        {Self, then} ->
+            io:format("前"),
+            Self ! done,
+            rad_process();
+        _ -> exit("rad process received unexpected message")
+    end.


### PR DESCRIPTION
Erlang/OTP 22 (Ubuntu 20.04 LTS) で動作確認済みです。

## 実行方法

実行するには `escript` (Erlang Script) コマンドが必要で、
これは apt の場合 `erlang` パッケージをインストールすることで入手できます。

```
chmod +x RADWIMPS.erl  # 実行権限を与える
./RADWIMPS.erl  # => 前前前世
```

## 動作原理

Erlang は BEAM という VM 上で軽量プロセスをたくさん作ってプロセス間で非同期メッセージパッシングをするのが特徴的な言語で、クラス定義に相当する言語機能はありません。
Erlang らしさを取り入れて then then then 世することを考えると、「サブプロセスを生成して、そこに then か 世 をメッセージとして送信し、サブプロセス側でそれに対応する文字が出力される」という仕組みに行き着きました。

`main/1` 関数がこのプログラムのエントリポイントで、`rad_process/0` 関数をもとにしてサブプロセスを spawn しています。
メッセージを送信するロジックは `send_sync/3` 関数に切り出しており、その名の通り (確実に 前 と 世 を正しい順番で出力するために) サブプロセス側の処理の完了を毎回待機しながら、同期的にメッセージを送っています。